### PR TITLE
Fix validator issue

### DIFF
--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -8,7 +8,7 @@ jobs:
     build_php:
         strategy:
             matrix:
-                php: [ '8.0', '8.1' ]
+                php: [ '8.1', '8.2' ]
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     ],
     "require": {
         "laravel/framework": "^8.0|^9.0|^10.0",
-        "php": "^8.0",
+        "php": "^8.1",
         "tobytwigger/form-schema-generator": "^3.0"
     },
     "require-dev": {

--- a/src/Decorators/ValidationDecorator.php
+++ b/src/Decorators/ValidationDecorator.php
@@ -37,10 +37,7 @@ class ValidationDecorator extends BaseSettingServiceDecorator
     private function validateValue(string $key, mixed $value)
     {
         $setting = $this->settingStore->getByKey($key);
-        $validator = Validator::make(
-            ['setting' => $value],
-            ['setting' => $setting->rules()]
-        );
+        $validator = $setting->validator($value);
         $validator->validate();
     }
 


### PR DESCRIPTION
- Bug where validation uses `rules()` not the setting `validator()` method (which by default uses `rules()`.
- This meant that you could not override the validator() method to validate properly